### PR TITLE
Dockerfile, README and startmain.sh minor fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
 FROM ubuntu:14.04
 MAINTAINER curtis <curtis@serverascode.com>
 
-#
-# supervisor
-#
+RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -c -s) universe" > /etc/apt/sources.list.d/universe.list
 
-RUN apt-get install -y supervisor
+RUN apt-get update
+RUN apt-get install -y supervisor swift python-swiftclient rsync \
+                       swift-proxy swift-object memcached python-keystoneclient \
+                       python-swiftclient swift-plugin-s3 python-netifaces \
+                       python-xattr python-memcache \
+                       swift-account swift-container swift-object pwgen
+
 RUN mkdir -p /var/log/supervisor
 ADD files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
@@ -13,20 +17,6 @@ ADD files/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Swift configuration
 # - Partially fom http://docs.openstack.org/developer/swift/development_saio.html
 #
-
-# common
-RUN apt-get update && apt-get install -y swift python-swiftclient rsync
-
-# proxy
-RUN apt-get install -y swift-proxy swift-object memcached python-keystoneclient \
-			           python-swiftclient swift-plugin-s3 python-netifaces \ 
-			           python-xattr python-memcache
-
-# storage
-RUN apt-get install -y swift-account swift-container swift-object 
-
-# passwords
-RUN apt-get install -y pwgen 
 
 # not sure how valuable dispersion will be...
 ADD files/dispersion.conf /etc/swift/dispersion.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM ubuntu:14.04
 MAINTAINER curtis <curtis@serverascode.com>
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu $(lsb_release -c -s) universe" > /etc/apt/sources.list.d/universe.list
-
 RUN apt-get update
 RUN apt-get install -y supervisor swift python-swiftclient rsync \
                        swift-proxy swift-object memcached python-keystoneclient \

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ vagrant@host1:~$ docker run -v /srv --name SWIFT_DATA busybox
 Now that we have a data container, we can use the "--volumes-from" option when creating the "onlyone" container. Note that in this case I've called the image built from this docker file "curtis/swift-onlyone".
 
 ```bash
-vagrant@host1:~$ ID=$(docker run -d -p 8080 --volumes-from SWIFT_DATA -t curtis/swift-onlyone)
+vagrant@host1:~$ ID=$(docker run -d -p 12345:8080 --volumes-from SWIFT_DATA -t curtis/swift-onlyone)
 ```
 
 With that container running we can now check the logs.
@@ -63,13 +63,13 @@ At this point OpenStack Swift is running.
 ```bash
 vagrant@host1:~$ docker ps
 CONTAINER ID        IMAGE                         COMMAND                CREATED             STATUS              PORTS                     NAMES
-4941f8cd8b48        curtis/swift-onlyone:latest   /bin/sh -c /usr/loca   58 seconds ago      Up 57 seconds       0.0.0.0:49182->8080/tcp   hopeful_brattain    
+4941f8cd8b48        curtis/swift-onlyone:latest   /bin/sh -c /usr/loca   58 seconds ago      Up 57 seconds       0.0.0.0:12345->8080/tcp   hopeful_brattain
 ```
 
-We can now use the swift python client to access Swift using the Docker forwarded port, in this example port 49182.
+We can now use the swift python client to access Swift using the Docker forwarded port, in this example port 12345.
 
 ```bash
-vagrant@host1:~$ swift -A http://127.0.0.1:49182/auth/v1.0 -U test:tester -K testing stat
+vagrant@host1:~$ swift -A http://127.0.0.1:12345/auth/v1.0 -U test:tester -K testing stat
        Account: AUTH_test
     Containers: 0
        Objects: 0
@@ -83,7 +83,7 @@ X-Put-Timestamp: 1402463864.77057
 Try uploading a file:
 
 ```bash
-vagrant@host1:~$ swift -A http://127.0.0.1:49182/auth/v1.0 -U test:tester -K testing upload swift swift.txt
+vagrant@host1:~$ swift -A http://127.0.0.1:12345/auth/v1.0 -U test:tester -K testing upload swift swift.txt
 swift.txt
 ```
 

--- a/files/startmain.sh
+++ b/files/startmain.sh
@@ -54,7 +54,7 @@ if [ ! -z "${SWIFT_STORAGE_URL_SCHEME}" ]; then
 	grep "storage_url_scheme" /etc/swift/proxy-server.conf
 fi
 
-if [ ! -z "SWIFT_SET_PASSWORDS" ]; then
+if [ ! -z "${SWIFT_SET_PASSWORDS}" ]; then
 	echo "Setting passwords in /etc/swift/proxy-server.conf"
 	PASS=`pwgen 12 1`
 	sed -i -e "s/user_admin_admin = admin .admin .reseller_admin/user_admin_admin = $PASS .admin .reseller_admin/g" /etc/swift/proxy-server.conf


### PR DESCRIPTION
Worked pretty well for me for the most part except for a couple of very minor things:
-  The test for the `SWIFT_SET_PASSWORDS` env variable wasn't working so the password was being auto-generated by default. Some README instructions are not correct as a result, since the static password `testing` isn't valid for testing with the swift client. 
- `apt-get update` to refresh the package index needs to happen before installing `supervisor`, otherwise `apt-get install supervisor` fails.
- Use a static host port for the swift proxy, so copy/paste from the README works when testing with the swift client.
